### PR TITLE
Drop Symfony 7 & EasyAdmin 4 support, require Symfony 8 and EasyAdmin 5

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['8.2', '8.4']
+        php-version: ['8.4']
 
     steps:
       - name: Checkout repository
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['8.2', '8.4']
+        php-version: ['8.4']
 
     steps:
       - name: Checkout repository
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['8.2', '8.4']
+        php-version: ['8.4']
 
     steps:
       - name: Checkout repository
@@ -139,8 +139,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - php-version: '8.2'
-            symfony-version: '7.4'
           - php-version: '8.4'
             symfony-version: '8.0'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Changelog
 
-## [1.0.7](https://github.com/enabel/partner-countries-bundle/tree/1.0.7) (2024-11-09)
+## [v1.1.0](https://github.com/enabel/partner-countries-bundle/tree/v1.1.0) (2026-06-10)
+
+[Full Changelog](https://github.com/enabel/partner-countries-bundle/compare/v1.0.8...v1.1.0)
+
+**Breaking changes:**
+
+- Drop Symfony 7 support, require Symfony 8.0+ and PHP 8.4+
+- Drop EasyAdmin 4 support, require EasyAdmin 5
+- `CountryTrait::countryMenuEntry()` now links to the CRUD controller instead of the entity (`MenuItem::linkToCrud()` was removed in EasyAdmin 5): apps using the trait must set the new `country_admin_controller` option to their controller extending `CountryCrudController`
+
+**Implemented enhancements:**
+
+- New `country_admin_controller` configuration option
+- Explicit `symfony/console` requirement (the bundle ships a console command)
+- Upgrade dev tools: PHPStan 2, phpstan-phpunit 2, PHPUnit 11, PHP Insights 2.14
+
+## [v1.0.8](https://github.com/enabel/partner-countries-bundle/tree/v1.0.8) (2026-02-10)
+
+[Full Changelog](https://github.com/enabel/partner-countries-bundle/compare/1.0.7...v1.0.8)
+
+**Merged pull requests:**
+
+- Drop Symfony 6 support, add Symfony 7 & 8 compatibility [\#16](https://github.com/Enabel/partner-countries-bundle/pull/16) ([damienlagae](https://github.com/damienlagae))
+
+## [1.0.7](https://github.com/enabel/partner-countries-bundle/tree/1.0.7) (2024-11-07)
 
 [Full Changelog](https://github.com/enabel/partner-countries-bundle/compare/1.0.6...1.0.7)
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can check docs [here](docs/index.md)
 
 ## Versions & dependencies
 
-The current version of the bundle works with Symfony 6.0+.
+The current version of the bundle requires PHP 8.4+, Symfony 8.0+ and EasyAdmin 5.
 The project follows SemVer.
 
 You can check the [changelog](CHANGELOG.md).

--- a/composer.json
+++ b/composer.json
@@ -10,23 +10,24 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.4",
         "doctrine/migrations": "^3.7",
-        "easycorp/easyadmin-bundle": "^4.4",
-        "symfony/config": "^7.0|^8.0",
-        "symfony/dependency-injection": "^7.0|^8.0",
-        "symfony/framework-bundle": "^7.0|^8.0",
-        "symfony/intl": "^7.0|^8.0",
+        "easycorp/easyadmin-bundle": "^5.0",
+        "symfony/config": "^8.0",
+        "symfony/console": "^8.0",
+        "symfony/dependency-injection": "^8.0",
+        "symfony/framework-bundle": "^8.0",
+        "symfony/intl": "^8.0",
         "twig/twig": "^3.4"
     },
     "require-dev": {
-        "nunomaduro/phpinsights": "^2.6",
-        "phpstan/phpstan": "^1.8",
-        "phpstan/phpstan-phpunit": "^1.1",
-        "phpunit/phpunit": "^10.0|^11.0",
+        "nunomaduro/phpinsights": "^2.14",
+        "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpunit/phpunit": "^11.0",
         "squizlabs/php_codesniffer": "^3.7",
-        "symfony/phpunit-bridge": "^7.0|^8.0",
-        "symfony/yaml": "^7.0|^8.0"
+        "symfony/phpunit-bridge": "^8.0",
+        "symfony/yaml": "^8.0"
     },
     "minimum-stability": "stable",
     "autoload": {

--- a/docs/easyadmin.md
+++ b/docs/easyadmin.md
@@ -1,5 +1,14 @@
 # Manage partner countries in your Easyadmin dashboard
 
+The menu entry links to your CRUD controller, so make sure the `country_admin_controller` option
+points to your own controller extending the bundle one (see [installation](index.md)):
+
+```yaml
+# config/packages/enabel_partner_countries.yaml
+enabel_partner_countries:
+  country_admin_controller: 'App\Controller\Admin\Enabel\CountryCrudController'
+```
+
 Go to your dashboard controller, example : `src/Controller/Admin/DashboardController.php`
 
 ```php

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,6 +83,7 @@ Create a file `/config/packages/enabel_partner_countries.yaml` with this content
 enabel_partner_countries:
   country_class: 'App\Entity\Enabel\Country'
   country_repository: 'App\Repository\Enabel\CountryRepository'
+  country_admin_controller: 'App\Controller\Admin\Enabel\CountryCrudController'
 ```
 
 ### Step 5: Create entity & repository

--- a/src/Controller/Admin/CountryCrudController.php
+++ b/src/Controller/Admin/CountryCrudController.php
@@ -13,7 +13,11 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\BooleanField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\CountryField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use Enabel\PartnerCountriesBundle\Entity\Country;
 
+/**
+ * @extends AbstractCrudController<Country>
+ */
 abstract class CountryCrudController extends AbstractCrudController
 {
     public function configureCrud(Crud $crud): Crud

--- a/src/Controller/Admin/CountryTrait.php
+++ b/src/Controller/Admin/CountryTrait.php
@@ -7,6 +7,8 @@ namespace Enabel\PartnerCountriesBundle\Controller\Admin;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemInterface;
 use Iterator;
+use LogicException;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 trait CountryTrait
 {
@@ -16,11 +18,22 @@ trait CountryTrait
     public function countryMenuEntry(): iterable
     {
         $parameterBag = $this->container->get('parameter_bag');
+        if (!$parameterBag instanceof ParameterBagInterface) {
+            throw new LogicException('The "parameter_bag" service is not available.');
+        }
 
-        yield MenuItem::linkToCrud(
+        $controllerFqcn = $parameterBag->get('enabel_partner_countries.country_admin_controller');
+        if (!is_string($controllerFqcn) || !is_a($controllerFqcn, CountryCrudController::class, true)) {
+            throw new LogicException(sprintf(
+                'The "enabel_partner_countries.country_admin_controller" parameter must be a class extending "%s".',
+                CountryCrudController::class
+            ));
+        }
+
+        yield MenuItem::linkTo(
+            $controllerFqcn,
             'enabel_partner_countries.admin.menu.country',
-            'fa fa-earth-africa',
-            $parameterBag->get('enabel_partner_countries.country_class')
+            'fa fa-earth-africa'
         );
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Enabel\PartnerCountriesBundle\DependencyInjection;
 
+use Enabel\PartnerCountriesBundle\Controller\Admin\CountryCrudController;
 use Enabel\PartnerCountriesBundle\Entity\Country;
 use Enabel\PartnerCountriesBundle\Repository\CountryRepository;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
@@ -29,6 +30,23 @@ class Configuration implements ConfigurationInterface
                     throw new InvalidConfigurationException(sprintf(
                         'Country class must be a valid class extending %s. "%s" given.',
                         Country::class,
+                        $value
+                    ));
+                }
+
+                return $value;
+            })
+            ->end()
+            ->end()
+            ->scalarNode('country_admin_controller')
+            ->defaultValue(CountryCrudController::class)
+            ->validate()
+            ->ifString()
+            ->then(static function ($value): string {
+                if (!class_exists($value) || !is_a($value, CountryCrudController::class, true)) {
+                    throw new InvalidConfigurationException(sprintf(
+                        'Country admin controller must be a valid class extending %s. "%s" given.',
+                        CountryCrudController::class,
                         $value
                     ));
                 }

--- a/tests/DependencyInjection/PartnerCountriesBundleExtensionTest.php
+++ b/tests/DependencyInjection/PartnerCountriesBundleExtensionTest.php
@@ -43,6 +43,28 @@ class PartnerCountriesBundleExtensionTest extends TestCase
         $loader->load(['enabel_partner_countries' => $config], new ContainerBuilder());
     }
 
+    public function testThrowExceptionOnInvalidAdminControllerClass(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+
+        $loader = new PartnerCountriesBundleExtension();
+        $config = $this->getValidConfig();
+        if (is_array($config)) {
+            $config['country_admin_controller'] = 'Acme\MyBundle\Controller\Admin\CountryCrudController';
+        }
+        $loader->load(['enabel_partner_countries' => $config], new ContainerBuilder());
+    }
+
+    public function testAdminControllerClassWithDefaults(): void
+    {
+        $this->createEmptyConfiguration();
+
+        $this->assertParameter(
+            'Enabel\PartnerCountriesBundle\Controller\Admin\CountryCrudController',
+            'enabel_partner_countries.country_admin_controller'
+        );
+    }
+
     public function testModelClassWithDefaults(): void
     {
         $this->createEmptyConfiguration();
@@ -97,7 +119,6 @@ EOF;
         $loader = new PartnerCountriesBundleExtension();
         $config = $this->getValidConfig();
         $loader->load(['enabel_partner_countries' => $config], $this->configuration);
-        $this->assertTrue($this->configuration instanceof ContainerBuilder);
     }
 
     /**

--- a/tests/Utils/DashboardController.php
+++ b/tests/Utils/DashboardController.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Enabel\PartnerCountriesBundle\Tests\Utils;
+
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
+use Enabel\PartnerCountriesBundle\Controller\Admin\CountryTrait;
+
+class DashboardController extends AbstractDashboardController
+{
+    use CountryTrait;
+}


### PR DESCRIPTION
## Why

This internal bundle follows the migration of our apps to Symfony 8. Instead of maintaining a wide compatibility matrix, this narrows the requirements to a single major version of each dependency.

## Changes

### Requirements
- PHP `^8.4`, Symfony `^8.0`, EasyAdmin `^5.0`
- Explicit `symfony/console` requirement (the bundle ships `SyncCommand`, it was previously only a transitive dependency)

### EasyAdmin 5 compatibility
- `MenuItem::linkToCrud()` was removed in EasyAdmin 5; `CountryTrait` now uses `MenuItem::linkTo()`, which targets the CRUD controller instead of the entity
- New `country_admin_controller` config option (validated like the existing ones) so the menu entry knows which controller to link to
- `@extends AbstractCrudController<Country>` generic annotation, required by EasyAdmin 5

### ⚠️ Breaking change for consuming apps

Apps using `CountryTrait` must add the new option to their config:

```yaml
# config/packages/enabel_partner_countries.yaml
enabel_partner_countries:
  country_admin_controller: 'App\Controller\Admin\Enabel\CountryCrudController'
```

Note: EasyAdmin 5 also makes pretty URLs mandatory — that is an app-level migration step, not handled by this bundle.

### Tooling
- PHPStan 2 (PHPStan 1 cannot parse the PHP 8.4 syntax used by symfony/console 8.1), phpstan-phpunit 2, PHPUnit 11, PHP Insights 2.14
- New test fixture using `CountryTrait` so PHPStan actually analyses the trait
- CI matrices restricted to PHP 8.4 / Symfony 8.0

### Docs
- Installation & EasyAdmin docs updated with the new config option
- Changelog entry for v1.1.0

## QA

`composer qa` is green: phpcs, PHPStan level 9, PHP Insights, 8 tests / 12 assertions.
